### PR TITLE
fix(docker): Fix `apt` failures by upgrading to Ubuntu 24.04 LTS  

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.04
+FROM ubuntu:24.04
 
 # Prevents installdependencies.sh from prompting the user and blocking the image creation
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
### **PR Description:**  
This PR updates the Docker base image from **Ubuntu 23.04 (EOL)** to **Ubuntu 24.04 LTS** to resolve `apt update` failures caused by removed repositories.  

#### **Resolves**
- Closes #1.

#### **Changes:**  
- Replaced `ubuntu:23.04` with `ubuntu:24.04` in the **Dockerfile**.  
- Ensures `apt` package installation works without `404 Not Found` errors.  

#### **Why?**  
- Ubuntu 23.04 is no longer supported, breaking package installations.  
- Ubuntu 24.04 LTS provides long-term stability and security updates.  

#### **Impact:**  
- Fixes Docker build failures.  
- Ensures smooth setup for the self-hosted GitHub Actions runner.  
